### PR TITLE
feat: configurable concurrency for chunk uploads

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -468,7 +468,10 @@ export default function Home() {
                   ...prev,
                   [fileKey]: progress,
                 }));
-              }
+              },
+              // Use all available hardware threads for parallel chunk uploads
+              undefined,
+              navigator.hardwareConcurrency || 3
             );
           } else {
             console.log(


### PR DESCRIPTION
## Summary
- allow callers to specify chunk upload concurrency
- default concurrency to `navigator.hardwareConcurrency` for maximal throughput
- retry upload completion to survive transient server errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68acf66f8fc8833080a9479ead358554